### PR TITLE
Fix/regression json responses

### DIFF
--- a/vamp-json/VampJson.h
+++ b/vamp-json/VampJson.h
@@ -305,7 +305,7 @@ public:
             return {};
         }
 
-        od = toConfiguredOutputDescriptor(j, err);
+        od = toConfiguredOutputDescriptor(j["configured"], err);
         if (failed(err)) return {};
     
         toBasicDescriptor(j["basic"], od, err);

--- a/vamp-json/VampJson.h
+++ b/vamp-json/VampJson.h
@@ -1298,7 +1298,8 @@ public:
     static json11::Json
     fromError(std::string errorText,
               RRType responseType,
-              const json11::Json &id) {
+              const json11::Json &id,
+              bool writeVerbatimError = false) {
 
         json11::Json::object jo;
         markRPC(jo);
@@ -1315,7 +1316,7 @@ public:
         json11::Json::object eo;
         eo["code"] = 0;
 
-        if (responseType == RRType::NotValid) {
+        if (responseType == RRType::NotValid || writeVerbatimError) {
             eo["message"] = errorText;
         } else {
             eo["message"] = 

--- a/vamp-json/VampJson.h
+++ b/vamp-json/VampJson.h
@@ -1109,13 +1109,18 @@ private: // go private briefly for a couple of helper functions
 
     static bool
     successful(json11::Json j, std::string &err) {
-        if (j["result"].is_object()) {
-            return true;
-        } else if (j["error"].is_object()) {
+        const bool hasResult = j["result"].is_object();
+        const bool hasError = j["error"].is_object();
+        if (hasResult && hasError) {
+            err = "valid response may contain only one of result and error objects";
+            return false;
+        } else if (hasError) {
+            return false;
+        } else if (!hasResult) {
+            err = "either a result or an error object is required for a valid response";
             return false;
         } else {
-            err = "result or error object required for valid response";
-            return false;
+            return true;
         }
     }
 

--- a/vamp-json/VampJson.h
+++ b/vamp-json/VampJson.h
@@ -1109,11 +1109,11 @@ private: // go private briefly for a couple of helper functions
 
     static bool
     successful(json11::Json j, std::string &err) {
-        if (!j["success"].is_bool()) {
-            err = "bool expected for success";
+        if (!j["result"].is_object()) {
+            err = "result object expected for success";
             return false;
         }
-        return j["success"].bool_value();
+        return true;
     }
 
     static void

--- a/vamp-json/VampJson.h
+++ b/vamp-json/VampJson.h
@@ -849,7 +849,7 @@ public:
     toListResponse(json11::Json j, std::string &err) {
 
         ListResponse resp;
-        for (const auto &a: j["result"]["available"].array_items()) {
+        for (const auto &a: j["available"].array_items()) {
             resp.available.push_back(toPluginStaticData(a, err));
             if (failed(err)) return {};
         }

--- a/vamp-json/VampJson.h
+++ b/vamp-json/VampJson.h
@@ -1109,11 +1109,14 @@ private: // go private briefly for a couple of helper functions
 
     static bool
     successful(json11::Json j, std::string &err) {
-        if (!j["result"].is_object()) {
-            err = "result object expected for success";
+        if (j["result"].is_object()) {
+            return true;
+        } else if (j["error"].is_object()) {
+            return false;
+        } else {
+            err = "result or error object required for valid response";
             return false;
         }
-        return true;
     }
 
     static void

--- a/vamp-server/convert.cpp
+++ b/vamp-server/convert.cpp
@@ -295,8 +295,10 @@ readResponseJson(string &err, bool &eof)
     VampJson::BufferSerialisation serialisation =
         VampJson::BufferSerialisation::Array;
 
-    rr.success = j["success"].bool_value();
-    rr.errorText = j["errorText"].string_value();
+    const bool isSuccess = j["result"].is_object();
+    const bool isError = j["error"].is_object();
+    rr.success = isSuccess;
+    rr.errorText = isError ? j["error"]["message"].string_value() : "";
 
     switch (rr.type) {
 

--- a/vamp-server/convert.cpp
+++ b/vamp-server/convert.cpp
@@ -558,15 +558,8 @@ readInput(string format, RequestOrResponse::Direction direction, bool &eof)
     if (format == "json") {
         string err;
         auto result = readInputJson(direction, err, eof);
-        const bool isRecognisedError = !result.success && result.errorText != "";
-        
-        // if the RequestOrResponse (result) has been populated with success=false and an error message
-        // then the server returned a well formed error, it is safe to return it for conversion 
-        // -- but if err is populated, something else has gone wrong
-        if (isRecognisedError || err == "") 
-            return result;
-        else 
-            throw runtime_error(err);
+        if (err != "") throw runtime_error(err);
+        else return result;
     } else if (format == "capnp") {
         return readInputCapnp(direction, eof);
     } else {

--- a/vamp-server/test.sh
+++ b/vamp-server/test.sh
@@ -91,7 +91,7 @@ EOF
 #debugflag=-d
 debugflag=
 
-for request_response_conversion in none json_to_json json_to_capnp ; do 
+for request_response_conversion in none json_to_json json_to_capnp ; do # nb json_to_capnp must be last: see comment in else case
 
     ( export VAMP_PATH="$vampsdkdir"/examples ;
       while read request ; do

--- a/vamp-server/test.sh
+++ b/vamp-server/test.sh
@@ -27,7 +27,7 @@ respfile="$tmpdir/resp.json"
 allrespfile="$tmpdir/resp.all"
 input="$tmpdir/input"
 expected="$tmpdir/expected"
-expected_less_strict="$tmpdir/obtained-less-strict"
+expected_less_strict="$tmpdir/expected-less-strict"
 obtained="$tmpdir/obtained"
 
 validate() {

--- a/vamp-server/test.sh
+++ b/vamp-server/test.sh
@@ -83,7 +83,7 @@ cat > "$expected" <<EOF
 {"error": {"code": 0, "message": "error in finish request: unknown plugin handle supplied to finish"}, "id": "blah", "jsonrpc": "2.0", "method": "finish"}
 EOF
 
-# We run the whole test three times, 
+# We run the whole test three times,
 # to cover (de)serialisation of json and capnp requests and responses
 # as well as exercising both server modes (json and capnp)
 # converting / reading from capnp requests is currently not tested
@@ -121,10 +121,9 @@ for request_response_conversion in none json_to_json json_to_capnp ; do
     # Skip plugin lists
     tail -n +4 "$allrespfile" > "$obtained"
 
-    echo "Checking response contents against expected contents..."
-    
-    # the expected configuration response is fragile, capnp fills in optional fields, 
-    # json doesn't - which is fine behaviour, but causes the test to fail - remove empty binCount and binNames  
+    echo "Checking response contents against expected contents..."  
+    # the expected configuration response is fragile, capnp fills in optional fields,
+    # json doesn't - which is fine behaviour, but causes the test to fail - remove empty binCount and binNames
     expected_without_optional_fields=$( cat "$expected" | sed -E 's/\"(binCount|binNames)\": ?((\[\])|0),? ?//g')
     echo "$expected_without_optional_fields" > "$expected_less_strict"
 


### PR DESCRIPTION
A few small changes to fix some regressions caused by various schema changes in the past that were missed due to those areas not being used in any shipped code, or covered in the tests. 

I extended the test shell script to exercise writing JSON responses with the converter, which surfaced most of the areas I'd previously fixed to get the converter working. Additionally, fixed an issue regarding the converter doubling error messages (converter and simple-server both write JSON errors through the same function, so writing the error again resulted in the message being _"error in configure request: error in configure request: unknown plugin handle supplied to configure"_, for example).

I've also added comments to explain some less obvious decisions, which should've arguably been documented in better commit messages or through this PR in the code comments.