### PR TITLE
Fix erroneous logic for handling step and block size in prior commit

### DIFF
--- a/vamp-client/qt/AutoPlugin.h
+++ b/vamp-client/qt/AutoPlugin.h
@@ -138,14 +138,7 @@ public:
     virtual bool initialise(size_t inputChannels,
                             size_t stepSize,
                             size_t blockSize) {
-        try {
-            return getPlugin()->initialise(inputChannels, stepSize, blockSize);
-        } catch (const ServiceError &e) {
-            // Sadly, the Vamp API has taught hosts to try to divine
-            // initialisation problems from a bool return value alone
-            log(std::string("AutoPlugin: initialise failed: ") + e.what());
-            return false;
-        }
+        return getPlugin()->initialise(inputChannels, stepSize, blockSize);
     }
 
     virtual void reset() {

--- a/vamp-server/simple-server.cpp
+++ b/vamp-server/simple-server.cpp
@@ -495,7 +495,7 @@ handleRequest(const RequestOrResponse &request, bool debug)
             mapper.markConfigured
                 (h,
                  creq.configuration.channelCount,
-                 creq.configuration.framing.blockSize);
+                 response.configurationResponse.framing.blockSize);
             response.success = true;
         }
         break;
@@ -521,8 +521,12 @@ handleRequest(const RequestOrResponse &request, bool debug)
         const float **fbuffers = new const float *[channels];
         for (int i = 0; i < channels; ++i) {
             if (int(preq.inputBuffers[i].size()) != mapper.getBlockSize(h)) {
+                ostringstream os;
+                os << "wrong block size supplied to process ("
+                   << preq.inputBuffers[i].size()
+                   << ", expecting " << mapper.getBlockSize(h) << ")" << ends;
                 delete[] fbuffers;
-                throw runtime_error("wrong block size supplied to process");
+                throw runtime_error(os.str());
             }
             fbuffers[i] = preq.inputBuffers[i].data();
         }


### PR DESCRIPTION
The earlier change had a logical misconception. If PluginStub is
receiving the correct step and block size back from the configure call,
the plugin on the server side must have already been successfully
initialised, as the step and block size are only returned in a
successful configure response. This means the test for a failed
initialise and redo with the correct parameters must be done on the
server side (in LoaderRequests) not the client. The client has a more
complicated job, which is to notice that a *successful* configure had
returned different framing parameters from those passed to the
initialise call, and to pretend that it had actually failed until the
host called again with the correct parameters. We definitely need tests
for this!