### PR TITLE
Include headers needed to compile with GCC 15's -std=gnu23 default

### DIFF
--- a/ext/json11/json11.cpp
+++ b/ext/json11/json11.cpp
@@ -22,6 +22,7 @@
 #include "json11.hpp"
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <cstdio>
 #include <limits>

--- a/vamp-support/PluginHandleMapper.h
+++ b/vamp-support/PluginHandleMapper.h
@@ -38,6 +38,7 @@
 #include "PluginOutputIdMapper.h"
 
 #include <vamp-hostsdk/Plugin.h>
+#include <cstdint>
 #include <memory>
 
 namespace piper_vamp {


### PR DESCRIPTION
This fixes the build failure in Fedora's mass rebuild for the upcoming Fedora 42 release
https://bugzilla.redhat.com/show_bug.cgi?id=2341365

```
In file included from ../piper-vamp-cpp/vamp-json/VampJson.h:55,
                 from ../piper-vamp-cpp/vamp-server/convert.cpp:36:
../piper-vamp-cpp/vamp-support/PluginHandleMapper.h:69:13: error: ‘uint32_t’ does not name a type
   69 |     typedef uint32_t Handle;
      |             ^~~~~~~~
../piper-vamp-cpp/vamp-support/PluginHandleMapper.h:39:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   38 | #include "PluginOutputIdMapper.h"
  +++ |+#include <cstdint>
   39 |

../piper-vamp-cpp/ext/json11/json11.cpp: In function ‘void json11::dump(const std::string&, std::string&)’:
../piper-vamp-cpp/ext/json11/json11.cpp:95:32: error: ‘uint8_t’ does not name a type
   95 |         } else if (static_cast<uint8_t>(ch) <= 0x1f) {
      |                                ^~~~~~~
../piper-vamp-cpp/ext/json11/json11.cpp:25:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   24 | #include <cmath>
  +++ |+#include <cstdint>
   25 | #include <cstdlib>
```